### PR TITLE
feat : 앨범이름과 곡 이름이 같지 않은 테이블을 가져오는 쿼리 구현

### DIFF
--- a/lib/music_db/album.ex
+++ b/lib/music_db/album.ex
@@ -36,7 +36,28 @@ defmodule MusicDB.Album do
   # 앨범 제목이면서 트랙의 제목이 아닌것을 가져옴.
   def get_except_albums_and_tracks_title() do
     tracks_query = from(track in Track, [{:select, track.title}])
-    from(album in __MODULE__, [{:select, album.title}, {:except, ^tracks_query}])
+
+    from(album in __MODULE__, [
+      {:select, album.title},
+      {:except, ^tracks_query}
+    ])
+  end
+
+  # 앨범이름과 곡 이름이 같지 않은 앨범을 가져옴
+  def get_except_albums_and_tracks_last_title() do
+    same_track_album_by_title_query =
+      from(album in __MODULE__, [
+        {:as, :albums},
+        {:join, track in assoc(album, :tracks)},
+        {:on, album.title == track.title},
+        {:distinct, album.title},
+        {:select, album}
+      ])
+
+    from(album in __MODULE__, [
+      {:except, ^same_track_album_by_title_query},
+      {:select, album}
+    ])
   end
 
   def get_album_title_list_by_artist_name(artist_name) do


### PR DESCRIPTION
기존에 앨범이름과 곡이름이 같은 곡을 포함하지 않는 앨범만 가져오는 쿼리에서 원하던 값이 나오지 않고있었습니다.

원하는 결과값은 앨범 2개입니다.

-    title: "Kind Of Blue",
-    title: "Portrait In Jazz",

하지만 아래 작성하였던 코드에서 3개의 결과값이 나오고 있어서 수정하여서 PR 요청합니다!

## 기존에 작성하였던 코드

```elixir
  def get_except_albums_and_tracks_last_title(_number) do
    from(album in __MODULE__, [
      {:as, :albums},
      {:join, track in assoc(album, :tracks)},
      {:on, album.title != track.title},
      {:distinct, album.title},
      {:select, album}
    ])
  end
```

### 결과값

```elixir
[
  %MusicDB.Album{
    __meta__: #Ecto.Schema.Metadata<:loaded, "albums">,
    id: 1,
    title: "Kind Of Blue",
    inserted_at: ~N[2022-08-28 10:01:39],
    updated_at: ~N[2022-08-28 10:01:39],
    artist_id: 1,
    artist: #Ecto.Association.NotLoaded<association :artist is not loaded>,
    tracks: #Ecto.Association.NotLoaded<association :tracks is not loaded>
  },
  %MusicDB.Album{
    __meta__: #Ecto.Schema.Metadata<:loaded, "albums">,
    id: 3,
    title: "Portrait In Jazz",
    inserted_at: ~N[2022-08-29 03:42:29],
    updated_at: ~N[2022-08-29 03:42:29],
    artist_id: 2,
    artist: #Ecto.Association.NotLoaded<association :artist is not loaded>,
    tracks: #Ecto.Association.NotLoaded<association :tracks is not loaded>
  },
  %MusicDB.Album{
    __meta__: #Ecto.Schema.Metadata<:loaded, "albums">,
    id: 2,
    title: "You Must Believe In Spring",
    inserted_at: ~N[2022-08-29 03:42:29],
    updated_at: ~N[2022-08-29 03:42:29],
    artist_id: 2,
    artist: #Ecto.Association.NotLoaded<association :artist is not loaded>,
    tracks: #Ecto.Association.NotLoaded<association :tracks is not loaded>
  }
]

```
