### PR TITLE
feat : 트랙 동시성 테스트

### DIFF
--- a/lib/music_db.ex
+++ b/lib/music_db.ex
@@ -1,9 +1,42 @@
 defmodule MusicDB do
-  alias MusicDB.{Album, Artist, Repo, Track, Genre, Log}
+  alias MusicDB.{Album, Artist, Repo, Track, Genre, Log, AlbumWithEmbeds, TrackEmbed}
   alias SearchEngine
   import Ecto.Query
   import Ecto.Changeset
   alias Ecto.Multi
+
+  def insert_new_ablbum_with_embeds(album_title) do
+    params = %{
+      title: album_title,
+      artist: %{name: "YOUNG"},
+      tracks: [%{title: "KYU", duration: 500}]
+    }
+
+    AlbumWithEmbeds.changeset(%AlbumWithEmbeds{}, params)
+    |> Repo.insert()
+  end
+
+  def update_album_with_embeds(album_title) do
+    fn ->
+      AlbumWithEmbeds.by_title(album_title)
+      |> Repo.one()
+      |> change()
+      |> put_embed(:artist, %{name: "Arthur Blakey"})
+      |> put_embed(:tracks, [%TrackEmbed{title: "Moanin'"}])
+      |> Repo.update()
+    end
+    |> Repo.transaction()
+  end
+
+  def insert_ska_genres_on_conflict_nothing() do
+    Repo.insert_all("genres", [[{:name, "ska"}, {:wiki_tag, "Ska_music"}]], [
+      {:on_conflict, :nothing}
+    ])
+
+    Repo.insert_all("genres", [[{:name, "ska"}, {:wiki_tag, "Ska_music"}]], [
+      {:on_conflict, :nothing}
+    ])
+  end
 
   def add_artist_and_log(artist_name) do
     artist = Artist.changeset(%Artist{name: artist_name})

--- a/lib/music_db.ex
+++ b/lib/music_db.ex
@@ -23,6 +23,8 @@ defmodule MusicDB do
       |> change()
       |> put_embed(:artist, %{name: "Arthur Blakey"})
       |> put_embed(:tracks, [%TrackEmbed{title: "Moanin'"}])
+      # embed를 넣은뒤 검사를 진행 !
+      |> AlbumWithEmbeds.changeset(%{})
       |> Repo.update()
     end
     |> Repo.transaction()
@@ -163,6 +165,8 @@ defmodule MusicDB do
     |> Multi.insert(:artist, Artist.changeset(%Artist{}, %{name: artist_name}))
     |> Multi.insert(:album, fn %{artist: artist} ->
       Ecto.build_assoc(artist, :albums, %{title: album_title})
+      # build_assoc으로 관계 추가후 changeset으로 검사 !
+      |> Album.changeset(%{})
     end)
     |> Repo.transaction()
   end
@@ -241,6 +245,8 @@ defmodule MusicDB do
     album
     |> change()
     |> put_assoc(:genres, [new_genre | album.genres])
+    # 관계 추가후 changset으로 검사 !
+    |> Album.changeset(%{})
     |> Repo.update()
   end
 

--- a/lib/music_db/album_with_embeds.ex
+++ b/lib/music_db/album_with_embeds.ex
@@ -1,0 +1,10 @@
+defmodule MusicDB.AlbumWithEmbeds do
+  use Ecto.Schema
+  alias MusicDB.{ArtistEmbed, TrackEmbed}
+
+  schema "albums_with_embeds" do
+    field(:title, :string)
+    embeds_one(:artist, ArtistEmbed, [{:on_replace, :update}])
+    embeds_many(:tracks, TrackEmbed, [{:on_replace, :delete}])
+  end
+end

--- a/lib/music_db/album_with_embeds.ex
+++ b/lib/music_db/album_with_embeds.ex
@@ -1,10 +1,28 @@
 defmodule MusicDB.AlbumWithEmbeds do
   use Ecto.Schema
+  import Ecto.Query
+  import Ecto.Changeset
   alias MusicDB.{ArtistEmbed, TrackEmbed}
 
   schema "albums_with_embeds" do
     field(:title, :string)
     embeds_one(:artist, ArtistEmbed, [{:on_replace, :update}])
     embeds_many(:tracks, TrackEmbed, [{:on_replace, :delete}])
+  end
+
+  def changeset(struct, params) do
+    struct
+    |> cast(params, [:title])
+    |> cast_embed(:artist)
+    |> cast_embed(:tracks)
+    |> validate_required([:title])
+    |> validate_length(:title, [{:min, 1}, {:max, 100}])
+  end
+
+  def by_title(album_title) do
+    from(album in __MODULE__, [
+      {:where, album.title == ^album_title},
+      {:lock, "FOR UPDATE"}
+    ])
   end
 end

--- a/lib/music_db/artist_embed.ex
+++ b/lib/music_db/artist_embed.ex
@@ -1,0 +1,8 @@
+defmodule MusicDB.ArtistEmbed do
+  import Ecto.Changeset
+  use Ecto.Schema
+
+  embedded_schema do
+    field(:name)
+  end
+end

--- a/lib/music_db/artist_embed.ex
+++ b/lib/music_db/artist_embed.ex
@@ -5,4 +5,10 @@ defmodule MusicDB.ArtistEmbed do
   embedded_schema do
     field(:name)
   end
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:name])
+    |> validate_required([:name])
+  end
 end

--- a/lib/music_db/repo.ex
+++ b/lib/music_db/repo.ex
@@ -2,4 +2,8 @@ defmodule MusicDB.Repo do
   use Ecto.Repo,
     otp_app: :music_db,
     adapter: Ecto.Adapters.Postgres
+
+  def using_postgres? do
+    MusicDB.Repo.__adapter__() == Ecto.Adapters.Postgres
+  end
 end

--- a/lib/music_db/track_embed.ex
+++ b/lib/music_db/track_embed.ex
@@ -6,4 +6,10 @@ defmodule MusicDB.TrackEmbed do
     field(:title, :string)
     field(:duration, :integer)
   end
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:title, :durations])
+    |> validate_required([:title])
+  end
 end

--- a/lib/music_db/track_embed.ex
+++ b/lib/music_db/track_embed.ex
@@ -1,0 +1,9 @@
+defmodule MusicDB.TrackEmbed do
+  import Ecto.Changeset
+  use Ecto.Schema
+
+  embedded_schema do
+    field(:title, :string)
+    field(:duration, :integer)
+  end
+end

--- a/lib/music_db/track_embed.ex
+++ b/lib/music_db/track_embed.ex
@@ -9,7 +9,7 @@ defmodule MusicDB.TrackEmbed do
 
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:title, :durations])
+    |> cast(params, [:title, :duration])
     |> validate_required([:title])
   end
 end

--- a/priv/examples/Upserts/upserts_01.exs
+++ b/priv/examples/Upserts/upserts_01.exs
@@ -1,0 +1,37 @@
+# 값 넣기
+Repo.insert_all("genres", [[name: "ska", wiki_tag: "Ska_music"]])
+# => {1, nil}
+
+# 값을 또 넣으려고 하면 키가 중복된다는 에러메시지가 나온다
+Repo.insert_all("genres", [[name: "ska", wiki_tag: "Ska_music"]])
+# => ** (Postgrex.Error) ERROR 23505 (unique_violation): duplicate key
+# => value violates unique constraint "genres_name_index"
+
+# on_conflict 옵션을 nothing으로 주어 충돌시 아무런 일도 일어나지 않게했다.
+Repo.insert_all("genres", [[name: "ska", wiki_tag: "Ska_music"]],
+on_conflict: :nothing)
+# => {0, nil} 결과에서 0은 데이터베이스에서 바뀐 레코드가 없다는것을 의미한다.
+
+Repo.insert_all("genres", [[name: "ska", wiki_tag: "Ska"]],
+on_conflict: {:replace, [:wiki_tag]}, returning: [:wiki_tag])
+#=> ** (ArgumentError) :conflict_target option is required
+#=> when :on_conflict is replace  // 어떤 값의 충돌을 검사할것인지 명시적으로 적어야한다. 여기서는 name이다.
+
+# conflict_target을 명시적으로 적으니 충돌을 탐지하여 레코드를 넣었다 !
+Repo.insert_all("genres", [[name: "ska", wiki_tag: "Ska"]],
+on_conflict: {:replace, [:wiki_tag]}, conflict_target: :name,
+returning: [:wiki_tag])
+# => {1, [%{wiki_tag: "Ska"}]} // 새로운 값으로 업데이트되서 나온 값
+
+# 새로운 값을 넣었더니 비슷한 결과를 얻었다.
+# upsert는 insert update 여부와 무관하게 코드를 작성할수있게 해준다.
+Repo.insert_all("genres", [[name: "ambient", wiki_tag: "Ambient_music"]],
+on_conflict: {:replace, [:wiki_tag]}, conflict_target: :name,
+returning: [:wiki_tag])
+# => {1, [%{wiki_tag: "Ambient_music"}]}
+
+# on_conflict 옵션을 살짝 손봐줄수있다.
+# 마치 update_all 함수를 사용할때같다.
+Repo.insert_all("genres", [[name: "ambient", wiki_tag: "Ambient_music"]],
+on_conflict: [set: [wiki_tag: "Ambient_music"]],
+conflict_target: :name, returning: [:wiki_tag])

--- a/priv/examples/Upserts/upserts_02.exs
+++ b/priv/examples/Upserts/upserts_02.exs
@@ -1,0 +1,41 @@
+# 스키마를 사용하여 값을 넣을때
+genre = %Genre{name: "funk", wiki_tag: "Funk"}
+Repo.insert(genre)
+#=> {:ok,
+#=> %MusicDB.Genre{__meta__: #Ecto.Schema.Metadata<:loaded, "genres">,
+#=> albums: #Ecto.Association.NotLoaded<association :albums is not loaded>,
+#=> id: 3, inserted_at: ~N[2018-03-05 14:26:13], name: "funk",
+#=> updated_at: ~N[2018-03-05 14:26:13], wiki_tag: "Funk"}}
+
+# insert에 on_conflict 옵션 또한 줄수있다.
+Repo.insert(genre, on_conflict: [set: [wiki_tag: "Funk_music"]],
+conflict_target: :name)
+#=> {:ok,
+#=> %MusicDB.Genre{__meta__: #Ecto.Schema.Metadata<:loaded, "genres">,
+#=> albums: #Ecto.Association.NotLoaded<association :albums is not loaded>,
+#=> id: 3,inserted_at: ~N[2018-03-05 14:27:14], name: "funk",
+#=> updated_at: ~N[2018-03-05 14:27:14], wiki_tag: "Funk"}} // ?? 하지만 분명히 충돌했을시에 값을 바꿨는데 wiki_tag가 바뀌어있지 않다
+
+# 데이터베이스를 조회해보니 값은 정상적으로 바뀌어있다.
+Repo.get(Genre, 3)
+#=> %MusicDB.Genre{__meta__: #Ecto.Schema.Metadata<:loaded, "genres">,
+#=> albums: #Ecto.Association.NotLoaded<association :albums is not loaded>,
+#=> id: 3,inserted_at: ~N[2018-03-05 14:26:13], name: "funk",
+#=> updated_at: ~N[2018-03-05 14:26:13], wiki_tag: "Funk_music"}
+
+# wiki_tag의 값은 변했다.
+# 그리고 inserted_at과 updated_at값은 변하지 않았다.
+# 데이터베이스의 record는 정확하다 하지만 insert를 사용한 return값은 그것을 반영하지 않았다.
+# 그 이유는 :on_conflict를 키워드 리스트에 사용할때 Ecto는 upsert를 수행한후 전체 레코드를 다시 읽지 않기 때문이다.
+# 업데이트 중인 값과 Ecto에게 반환을 요청한 값 사이에 불일치가 있으면 반환된 구조체가 데이터베이스에 있는 값을 정확하게 반영하지 못할수도있다.
+
+# replace_all_except_primary_key를 사용하여 key를 제외한 모든 값을 우리가 준 구조체 값으로 변경한다.
+genre = %Genre{name: "funk", wiki_tag: "Funky_stuff"}
+Repo.insert(genre, on_conflict: :replace_all_except_primary_key,
+conflict_target: :name)
+#=> {:ok,
+#=>   %MusicDB.Genre{
+#=>     __meta__: #Ecto.Schema.Metadata<:loaded, "genres">,
+#=>     albums: #Ecto.Association.NotLoaded<association :albums is not loaded>,
+#=>     id: 3, inserted_at: ~N[2018-03-05 23:01:28], name: "funk",
+#=>     updated_at: ~N[2018-03-05 23:01:28], wiki_tag: "Funky_stuff" }}

--- a/priv/repo/migrations/20220908025924_add_albums_with_embeds.exs
+++ b/priv/repo/migrations/20220908025924_add_albums_with_embeds.exs
@@ -1,0 +1,12 @@
+defmodule MusicDB.Repo.Migrations.AddAlbumsWithEmbeds do
+  use Ecto.Migration
+
+  @table "albums_with_embeds"
+  def change do
+    create table(@table) do
+      add(:title, :string)
+      add(:artist, :jsonb)
+      add(:tracks, {:array, :jsonb}, default: [])
+    end
+  end
+end

--- a/priv/repo/migrations/20220908080745_add_notes_tables.exs
+++ b/priv/repo/migrations/20220908080745_add_notes_tables.exs
@@ -1,0 +1,55 @@
+defmodule MusicDB.Repo.Migrations.AddNotesTables do
+  use Ecto.Migration
+
+
+
+  @table :notes_with_fk_fields
+  def change do
+
+    create table(@table) do
+      add(:note, :text, [{:null, false}])
+      add(:author, :string, [{:null, false}])
+      add(:artist_id , references(:artists))
+      add(:album_id,  references(:albums))
+      add(:track_id,  references(:tracks))
+      timestamps()
+    end
+
+    if MusicDB.Repo.using_postgres?() do
+      fk_check = """
+        (CASE WHEN artist_id IS NULL THEN 0 ELSE 1 END) +
+        (CASE WHEN album_id IS NULL THEN 0 ELSE 1 END) +
+        (CASE WHEN track_id IS NULL THEN 0 ELSE 1 END) = 1
+      """
+      create constraint(:notes_with_fk_fields, :only_one_fk, check: fk_check)
+    end
+
+    create table(:notes_for_artists) do
+      add :note, :text, null: false
+      add :author, :string, null: false
+      add :assoc_id, references(:artists)
+      timestamps()
+    end
+
+    create table(:notes_for_albums) do
+      add :note, :text, null: false
+      add :author, :string, null: false
+      add :assoc_id, references(:albums)
+      timestamps()
+    end
+
+    create table(:notes_for_tracks) do
+      add :note, :text, null: false
+      add :author, :string, null: false
+      add :assoc_id, references(:tracks)
+      timestamps()
+    end
+
+    create table(:notes_with_joins) do
+      add :note, :text, null: false
+      add :author, :string, null: false
+      timestamps()
+    end
+
+  end
+end

--- a/priv/repo/migrations/20220908095944_add_notes_join_tables.exs
+++ b/priv/repo/migrations/20220908095944_add_notes_join_tables.exs
@@ -1,0 +1,26 @@
+defmodule MusicDB.Repo.Migrations.AddNotesJoinTables do
+  use Ecto.Migration
+
+  def change do
+    create table(:artists_notes) do
+      add :artist_id, references(:artists)
+      add :note_id, references(:notes_with_joins)
+    end
+    create index(:artists_notes, :artist_id)
+    create index(:artists_notes, :note_id)
+
+    create table(:albums_notes) do
+      add :album_id, references(:albums)
+      add :note_id, references(:notes_with_joins)
+    end
+    create index(:albums_notes, :album_id)
+    create index(:albums_notes, :note_id)
+
+    create table(:tracks_notes) do
+      add :track_id, references(:tracks)
+      add :note_id, references(:notes_with_joins)
+    end
+    create index(:tracks_notes, :track_id)
+    create index(:tracks_notes, :note_id)
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,5 +1,5 @@
 alias MusicDB.Repo
-alias MusicDB.{Artist, Album, Track, Genre}
+alias MusicDB.{Artist, Album, Track, Genre, AlbumWithEmbeds, ArtistEmbed, TrackEmbed}
 
 %Artist{
   name: "Miles Davis",
@@ -149,3 +149,38 @@ alias MusicDB.{Artist, Album, Track, Genre}
   ]
 }
 |> Repo.insert()
+
+if Repo.using_postgres?() do
+  Repo.insert! %AlbumWithEmbeds{
+    title: "Moanin'",
+    artist: %ArtistEmbed{
+      name: "Art Blakey"
+    },
+    tracks: [
+      %TrackEmbed{
+        title: "Moanin'",
+        duration: 575
+      },
+      %TrackEmbed{
+        title: "Are You Real",
+        duration: 290
+      },
+      %TrackEmbed{
+        title: "Along Came Betty",
+        duration: 372
+      },
+      %TrackEmbed{
+        title: "The Drum Thunder Suite",
+        duration: 453
+      },
+      %TrackEmbed{
+        title: "Blues March",
+        duration: 377
+      },
+      %TrackEmbed{
+        title: "Come Rain or Come Shine",
+        duration: 349
+      }
+    ]
+  }
+end

--- a/test/music_db/track_test.exs
+++ b/test/music_db/track_test.exs
@@ -26,11 +26,11 @@ defmodule MusicDB.TrackTest do
     end
 
     tasks = [
-      Task.start(play_function),
-      Task.start(play_function),
-      Task.start(play_function),
-      Task.start(play_function),
-      Task.start(play_function)
+      Task.start(fn -> play_function |> MusicDB.Repo.transaction() end),
+      Task.start(fn -> play_function |> MusicDB.Repo.transaction() end),
+      Task.start(fn -> play_function |> MusicDB.Repo.transaction() end),
+      Task.start(fn -> play_function |> MusicDB.Repo.transaction() end),
+      Task.start(fn -> play_function |> MusicDB.Repo.transaction() end)
     ]
 
     Enum.map(tasks, fn {:ok, task} ->

--- a/test/music_db/track_test.exs
+++ b/test/music_db/track_test.exs
@@ -1,0 +1,45 @@
+defmodule MusicDB.TrackTest do
+  use ExUnit.Case, async: true
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MusicDB.Repo)
+  end
+
+  test "update track" do
+    play_function = fn ->
+      receive do
+        :continue -> :ok
+      end
+
+      "So What"
+      |> MusicDB.Track.by_title()
+      |> MusicDB.Repo.one!()
+      |> then(fn track ->
+        MusicDB.Track.changeset(track, %{number_of_plays: track.number_of_plays + 1})
+      end)
+      |> then(fn changeset ->
+        changeset |> MusicDB.Repo.update()
+      end)
+      |> then(fn {:ok, track} ->
+        IO.inspect(track.number_of_plays)
+      end)
+    end
+
+    tasks = [
+      Task.start(play_function),
+      Task.start(play_function),
+      Task.start(play_function),
+      Task.start(play_function),
+      Task.start(play_function)
+    ]
+
+    Enum.map(tasks, fn {:ok, task} ->
+      Ecto.Adapters.SQL.Sandbox.allow(MusicDB.Repo, self(), task)
+      send(task, :continue)
+    end)
+
+    Process.sleep(5_000)
+    # number_of_plays에서 1이 나옵니다.
+    assert MusicDB.Repo.get(MusicDB.Track, 1).number_of_plays == 5
+  end
+end


### PR DESCRIPTION
동시성 테스트를 위한 테스트 코드 작성중에 

MusicDB.Track.by_title()함수에 lock을 구현했음에도 불구하고 테스트 결과가 1이 나옵니다.

레이스컨디션이 발생하고있는것일까요 ?

아니면 Ecto의 Sandbox를 잘못 사용하고 있는걸까요?

### MusicDB.Track.by_title()

```elixir
  def by_title(title) do
    from(
      track in __MODULE__,
      [
        {:where, track.title == ^title},
        {:lock, "FOR UPDATE"}
      ]
    )
  end
```

### MusicDB.Track.changeset()

```elixir
  def changeset(struct, params \\ %{}) do
    struct
    |> cast(params, [:title, :index, :number_of_plays])
    |> validate_required([:title])
  end
```

### MusicDB.track_tast

```elixir
defmodule MusicDB.TrackTest do
  use ExUnit.Case, async: true

  setup do
    :ok = Ecto.Adapters.SQL.Sandbox.checkout(MusicDB.Repo)
  end

  test "update track" do
    play_function = fn ->
      receive do
        :continue -> :ok
      end

      "So What"
      |> MusicDB.Track.by_title()
      |> MusicDB.Repo.one!()
      |> then(fn track ->
        MusicDB.Track.changeset(track, %{number_of_plays: track.number_of_plays + 1})
      end)
      |> then(fn changeset ->
        changeset |> MusicDB.Repo.update()
      end)
      |> then(fn {:ok, track} ->
        IO.inspect(track.number_of_plays)
      end)
    end

    tasks = [
      Task.start(play_function),
      Task.start(play_function),
      Task.start(play_function),
      Task.start(play_function),
      Task.start(play_function)
    ]

    Enum.map(tasks, fn {:ok, task} ->
      Ecto.Adapters.SQL.Sandbox.allow(MusicDB.Repo, self(), task)
      send(task, :continue)
    end)

    Process.sleep(5_000)
    # number_of_plays에서 1이 나옵니다.
    assert MusicDB.Repo.get(MusicDB.Track, 1).number_of_plays == 5
  end
end

```